### PR TITLE
[refactor] update script name to a correct one from `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Command | Description
 --- | ---
-`npm run dev` | App served @ `http://localhost:8181` with nodemon
+`npm run start:dev` | App served @ `http://localhost:8181` with nodemon
 `npm run start` | App served @ `http://localhost:8181` without nodemon
 
 **Note**: replace `npm` with `yarn` in `package.json` if you use yarn.


### PR DESCRIPTION
In `package.json`, there is no `dev` script, but `start:dev` for development:

https://github.com/rolling-scopes-school/remote-control/blob/22e250f66adabf8ee91cbe8ede43182309068724/package.json#L9

This PR fixes this mistake.